### PR TITLE
Add support for parameters on paths.

### DIFF
--- a/Sources/Enums.swift
+++ b/Sources/Enums.swift
@@ -20,7 +20,7 @@ public enum APIKeyLocation: String, Codable {
 }
 
 /// The HTTP verb corresponding to the operation's type.
-public enum OperationType: String, Codable {
+public enum OperationType: String, CaseIterable, Codable {
     case get
     case put
     case post


### PR DESCRIPTION
Before this change, any spec with parameters at the root of a path would fail to parse.